### PR TITLE
feat: add incremental ID support to tweets for improved pagination and querying

### DIFF
--- a/api/database/entities/Tweet.js
+++ b/api/database/entities/Tweet.js
@@ -9,6 +9,11 @@ export const Tweet = new EntitySchema({
       type: 'uuid',
       generated: 'uuid',
     },
+    incrementalId: {
+      type: 'int',
+      generated: 'increment',
+      comment: 'Auto-incrementing ID for range queries and pagination',
+    },
     userId: {
       type: 'uuid',
     },

--- a/api/database/migrations/1620000000001-AddIncrementalIdToTweets.js
+++ b/api/database/migrations/1620000000001-AddIncrementalIdToTweets.js
@@ -1,0 +1,30 @@
+/**
+ * Migration to add an auto-incrementing serial ID to tweets table
+ */
+export class AddIncrementalIdToTweets1620000000001 {
+  async up(queryRunner) {
+    // Add incrementalId column as a serial (auto-incrementing) type
+    await queryRunner.query(`
+      ALTER TABLE tweets
+      ADD COLUMN "incrementalId" SERIAL NOT NULL;
+    `);
+
+    // Create an index on incrementalId for faster range queries
+    await queryRunner.query(`
+      CREATE INDEX "tweets_incremental_id_idx" ON tweets ("incrementalId");
+    `);
+  }
+
+  async down(queryRunner) {
+    // Drop the index first
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "tweets_incremental_id_idx";
+    `);
+
+    // Then drop the column
+    await queryRunner.query(`
+      ALTER TABLE tweets
+      DROP COLUMN IF EXISTS "incrementalId";
+    `);
+  }
+} 

--- a/api/routes/twitter.js
+++ b/api/routes/twitter.js
@@ -404,6 +404,18 @@ async function twitterRoutes(fastify, options) {
             description: 'Offset for pagination',
             example: 0
           },
+          fromId: { 
+            type: 'integer', 
+            minimum: 1,
+            description: 'Start from this incrementalId (inclusive)',
+            example: 500
+          },
+          toId: { 
+            type: 'integer', 
+            minimum: 1,
+            description: 'End at this incrementalId (inclusive)',
+            example: 1500
+          },
           type: { 
             type: 'string', 
             enum: ['original', 'reply', 'retweet', 'quote'],
@@ -476,11 +488,13 @@ async function twitterRoutes(fastify, options) {
   }, async (request, reply) => {
     try {
       const { username } = request.params;
-      const { limit, offset, type, sortBy, sortOrder, startDate, endDate } = request.query;
+      const { limit, offset, fromId, toId, type, sortBy, sortOrder, startDate, endDate } = request.query;
       
       const tweets = await twitterService.getUserTweets(username, {
         limit: parseInt(limit),
         offset: parseInt(offset),
+        fromId: parseInt(fromId),
+        toId: parseInt(toId),
         type,
         sortBy,
         sortOrder,
@@ -559,6 +573,55 @@ async function twitterRoutes(fastify, options) {
         error: error.message, 
         message: 'Analytics not found. Run a scraping job first and then process the tweets with analytics'
       };
+    }
+  });
+
+  // Get incrementalId range for a user 
+  fastify.get('/tweets/:username/range', {
+    schema: {
+      description: 'Get the min and max incrementalId for a specific user',
+      tags: ['tweets'],
+      params: {
+        type: 'object',
+        properties: {
+          username: { 
+            type: 'string',
+            description: 'Twitter username',
+            example: 'elonmusk'
+          }
+        },
+        required: ['username']
+      },
+      response: {
+        200: {
+          description: 'IncrementalId range information',
+          type: 'object',
+          properties: {
+            username: { type: 'string', example: 'elonmusk' },
+            minId: { type: 'integer', example: 1 },
+            maxId: { type: 'integer', example: 5000 },
+            totalTweets: { type: 'integer', example: 5000 }
+          }
+        },
+        404: {
+          description: 'User not found or has no tweets',
+          type: 'object',
+          properties: {
+            error: { type: 'string', example: 'User not found or has no tweets' }
+          }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { username } = request.params;
+      const range = await twitterService.getTweetIdRange(username);
+      
+      return range;
+    } catch (error) {
+      fastify.log.error(`Failed to get tweet ID range: ${error.message}`);
+      reply.code(404);
+      return { error: error.message };
     }
   });
 

--- a/api/services/TwitterService.js
+++ b/api/services/TwitterService.js
@@ -232,6 +232,8 @@ class TwitterService {
     const {
       limit = 20,
       offset = 0,
+      fromId = null,
+      toId = null,
       type = null,
       sortBy = 'postedAt',
       sortOrder = 'DESC',
@@ -251,12 +253,18 @@ class TwitterService {
     // Build query
     const queryBuilder = this.repositories.tweet
       .createQueryBuilder('tweet')
-      .where('tweet.userId = :userId', { userId: user.id })
-      .orderBy(`tweet.${sortBy}`, sortOrder)
-      .skip(offset)
-      .take(limit);
-
-    // Apply filters
+      .where('tweet.userId = :userId', { userId: user.id });
+    
+    // Apply incrementalId range filter if provided
+    if (fromId !== null && !isNaN(fromId)) {
+      queryBuilder.andWhere('tweet.incrementalId >= :fromId', { fromId });
+    }
+    
+    if (toId !== null && !isNaN(toId)) {
+      queryBuilder.andWhere('tweet.incrementalId <= :toId', { toId });
+    }
+    
+    // Apply other filters
     if (type) {
       queryBuilder.andWhere('tweet.type = :type', { type });
     }
@@ -268,6 +276,20 @@ class TwitterService {
     if (endDate) {
       queryBuilder.andWhere('tweet.postedAt <= :endDate', { endDate });
     }
+    
+    // Add ordering
+    queryBuilder.orderBy(`tweet.${sortBy}`, sortOrder);
+    
+    // If no incrementalId range is specified, apply limit and offset
+    if (fromId === null && toId === null) {
+      queryBuilder.skip(offset).take(limit);
+    } else {
+      // When using incrementalId range, we don't apply skip/take by default
+      // but we still respect the limit if specified
+      if (limit) {
+        queryBuilder.take(limit);
+      }
+    }
 
     // Execute query with count
     const [tweets, total] = await queryBuilder.getManyAndCount();
@@ -278,8 +300,52 @@ class TwitterService {
         total,
         offset,
         limit,
+        fromId: fromId || null,
+        toId: toId || null,
         hasMore: offset + tweets.length < total,
       }
+    };
+  }
+
+  /**
+   * Get the min and max incrementalId for a specific user
+   * 
+   * @param {string} username - Twitter username
+   * @returns {Object} - Min and max incrementalId information
+   */
+  async getTweetIdRange(username) {
+    // Find user in database
+    const user = await this.repositories.user.findOne({ 
+      where: { username } 
+    });
+
+    if (!user) {
+      throw new Error(`User @${username} not found`);
+    }
+
+    // Get min and max incrementalId from tweets table
+    const result = await this.repositories.tweet
+      .createQueryBuilder('tweet')
+      .select('MIN(tweet.incrementalId)', 'minId')
+      .addSelect('MAX(tweet.incrementalId)', 'maxId')
+      .addSelect('COUNT(tweet.id)', 'totalTweets')
+      .where('tweet.userId = :userId', { userId: user.id })
+      .getRawOne();
+    
+    // Convert values to numbers (they come as strings from raw query)
+    const minId = result.minId !== null ? parseInt(result.minId) : null;
+    const maxId = result.maxId !== null ? parseInt(result.maxId) : null;
+    const totalTweets = parseInt(result.totalTweets) || 0;
+    
+    if (totalTweets === 0 || minId === null || maxId === null) {
+      throw new Error(`No tweets found for user @${username}`);
+    }
+    
+    return {
+      username,
+      minId,
+      maxId,
+      totalTweets
     };
   }
 


### PR DESCRIPTION
feat: add incremental ID support to tweets for improved pagination and querying

- Introduced an auto-incrementing `incrementalId` column in the tweets table to facilitate range queries and pagination.
- Updated the Twitter API routes to support filtering tweets by `fromId` and `toId` for enhanced data retrieval.
- Added a new endpoint to retrieve the minimum and maximum `incrementalId` for a specific user.
- Enhanced the TwitterService to handle the new `incrementalId` logic in tweet queries.

<img width="770" alt="Screenshot 2025-03-21 at 5 38 06 PM" src="https://github.com/user-attachments/assets/66f6f93c-6bc3-49be-a3b2-8ab29eb6a221" />
