### PR TITLE
feat: implement automatic job cleanup for stuck jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ RATE_LIMIT_MAX_DELAY=900000         # Maximum delay for rate limit backoff (ms)
 RATE_LIMIT_DURATION=900000          # How long to mark a user as rate limited (ms)
 RATE_LIMIT_KEY_EXPIRY=900           # Redis key expiry for rate limit flags (seconds)
 
+# Automatic Job Cleanup Settings
+ENABLE_AUTO_JOB_CLEANUP=true        # Enable automatic cleanup of stuck jobs
+JOB_CLEANUP_INTERVAL_HOURS=12       # How often to run the job cleanup process (hours)
+STUCK_JOB_THRESHOLD_HOURS=24        # Consider jobs stuck after this many hours (hours)
+
 # Redis Key Settings
 NON_RETRIABLE_KEY_EXPIRY=86400      # Redis key expiry for non-retriable flags (seconds)
 PROGRESS_KEY_EXPIRY=3600            # Redis key expiry for progress tracking (seconds)

--- a/api/plugins/queue.js
+++ b/api/plugins/queue.js
@@ -643,6 +643,72 @@ async function queuePlugin(fastify, options) {
       }
     });
   }
+
+  // Set up automatic cleanup for stuck jobs
+  let cleanupInterval = null;
+  
+  // Read environment variables for cleanup settings
+  const enableAutoCleanup = process.env.ENABLE_AUTO_JOB_CLEANUP === 'true';
+  const cleanupIntervalHours = parseInt(process.env.JOB_CLEANUP_INTERVAL_HOURS) || 12; // Default: check every 12 hours
+  const stuckJobThresholdHours = parseInt(process.env.STUCK_JOB_THRESHOLD_HOURS) || 24; // Default: jobs stuck for 24+ hours
+  
+  if (enableAutoCleanup) {
+    fastify.log.info(`Setting up automatic job cleanup to run every ${cleanupIntervalHours} hours for jobs stuck for ${stuckJobThresholdHours}+ hours`);
+    
+    // Convert to milliseconds
+    const intervalMs = cleanupIntervalHours * 60 * 60 * 1000;
+    
+    // Define the cleanup function
+    const cleanupStuckJobs = async () => {
+      try {
+        fastify.log.info(`Running scheduled cleanup of stuck jobs (threshold: ${stuckJobThresholdHours} hours)`);
+        
+        // We need to initialize the service here since it won't be available directly
+        const TwitterService = (await import('../services/TwitterService.js')).default;
+        const twitterService = new TwitterService(fastify);
+        
+        // Identify stuck jobs
+        const stuckJobs = await twitterService.identifyStuckJobs(stuckJobThresholdHours);
+        const totalStuckJobs = stuckJobs.twitterScraper.length + stuckJobs.tweetProcessor.length;
+        
+        if (totalStuckJobs === 0) {
+          fastify.log.info('No stuck jobs found during scheduled cleanup');
+          return;
+        }
+        
+        fastify.log.warn(`Found ${totalStuckJobs} stuck jobs during scheduled cleanup - attempting to terminate them`);
+        
+        // Perform the cleanup
+        const results = await twitterService.cleanupStuckJobs(stuckJobThresholdHours);
+        
+        // Log the results
+        const totalSuccess = results.twitterScraper.succeeded + results.tweetProcessor.succeeded;
+        const totalFailed = results.twitterScraper.failed + results.tweetProcessor.failed;
+        
+        fastify.log.info(`Scheduled cleanup completed: ${totalSuccess} jobs terminated, ${totalFailed} jobs failed to terminate`);
+      } catch (error) {
+        fastify.log.error(`Error during scheduled job cleanup: ${error.message}`);
+      }
+    };
+    
+    // Run cleanup immediately on startup (after a short delay to ensure everything is initialized)
+    setTimeout(() => {
+      cleanupStuckJobs().catch(err => {
+        fastify.log.error(`Failed to run initial job cleanup: ${err.message}`);
+      });
+    }, 60000); // 1 minute delay on startup
+    
+    // Set up the recurring interval
+    cleanupInterval = setInterval(cleanupStuckJobs, intervalMs);
+    
+    // Keep track of the interval to clean it up on shutdown
+    fastify.addHook('onClose', async (instance) => {
+      if (cleanupInterval) {
+        clearInterval(cleanupInterval);
+        fastify.log.info('Cleared job cleanup interval');
+      }
+    });
+  }
 }
 
 /**

--- a/api/plugins/swagger.js
+++ b/api/plugins/swagger.js
@@ -53,7 +53,9 @@ async function swaggerPlugin(fastify, options) {
         { name: 'processing', description: 'Endpoints for processing Twitter data' },
         { name: 'jobs', description: 'Endpoints for managing scraping and processing jobs' },
         { name: 'tweets', description: 'Endpoints for retrieving scraped tweets' },
-        { name: 'analytics', description: 'Endpoints for retrieving tweet analytics' }
+        { name: 'analytics', description: 'Endpoints for retrieving tweet analytics' },
+        { name: 'admin', description: 'Administrative endpoints for system management' },
+        { name: 'logs', description: 'Log file management endpoints' }
       ]
     }
   });

--- a/api/routes/twitter.js
+++ b/api/routes/twitter.js
@@ -700,43 +700,105 @@ async function twitterRoutes(fastify, options) {
   // Cancel a job
   fastify.delete('/jobs/:id', {
     schema: {
-      description: 'Cancel a specific job by ID',
+      description: 'Cancel a specific job by ID. Use force=true to forcibly unlock and cancel jobs that are locked by another worker.',
       tags: ['jobs'],
       params: {
         type: 'object',
         properties: {
           id: { 
             type: 'string',
-            description: 'Job ID',
-            example: '123456'
+            description: 'Job ID to cancel',
+            example: 'twitter-elonmusk-1624578901234'
           }
         },
         required: ['id']
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          force: {
+            type: 'boolean',
+            description: 'Force cancel even if job is locked by another worker',
+            default: false,
+            example: true
+          }
+        }
       },
       response: {
         200: {
           description: 'Job cancelled successfully',
           type: 'object',
           properties: {
-            message: { type: 'string', example: 'Job 123456 has been cancelled' }
+            message: { 
+              type: 'string', 
+              description: 'Success message',
+              example: 'Job twitter-elonmusk-1624578901234 has been cancelled' 
+            }
+          }
+        },
+        400: {
+          description: 'Job locked or other client error',
+          type: 'object',
+          properties: {
+            error: { 
+              type: 'string', 
+              description: 'Error message',
+              example: 'Job twitter-elonmusk-1624578901234 could not be removed because it is locked by another worker' 
+            },
+            suggestion: { 
+              type: 'string', 
+              description: 'Suggested solution',
+              example: 'Use ?force=true to forcefully unlock and cancel the job' 
+            }
           }
         },
         404: {
           description: 'Job not found',
           type: 'object',
           properties: {
-            error: { type: 'string', example: 'Job not found' }
+            error: { 
+              type: 'string', 
+              description: 'Error message',
+              example: 'Job not found' 
+            }
+          }
+        },
+        500: {
+          description: 'Error cancelling job',
+          type: 'object',
+          properties: {
+            error: { 
+              type: 'string', 
+              description: 'Error message',
+              example: 'Error cancelling job: Unknown error occurred' 
+            }
           }
         }
       }
     }
   }, async (request, reply) => {
     const { id } = request.params;
-    const success = await twitterService.cancelJob(id);
+    const { force = false } = request.query;
     
-    if (!success) {
-      reply.code(404);
-      return { error: 'Job not found' };
+    const result = await twitterService.cancelJob(id, force);
+    
+    if (!result.success) {
+      // Handle different error cases
+      if (result.error === 'Job not found') {
+        reply.code(404);
+        return { error: 'Job not found' };
+      } else if (result.errorType === 'locked' && result.needsForce) {
+        // Job is locked and force wasn't used
+        reply.code(400);
+        return { 
+          error: `Job ${id} could not be removed because it is locked by another worker`,
+          suggestion: 'Use ?force=true to forcefully unlock and cancel the job'
+        };
+      } else {
+        // Generic error case
+        reply.code(500);
+        return { error: `Error cancelling job: ${result.error}` };
+      }
     }
     
     return {
@@ -950,6 +1012,225 @@ async function twitterRoutes(fastify, options) {
       fastify.log.error(`Failed to get tweets view ID range: ${error.message}`);
       reply.code(404);
       return { error: error.message };
+    }
+  });
+
+  // Get stuck jobs
+  fastify.get('/stuck-jobs', {
+    schema: {
+      description: 'Identify jobs that have been stuck for longer than the specified threshold',
+      tags: ['jobs', 'admin'],
+      querystring: {
+        type: 'object',
+        properties: {
+          hours: {
+            type: 'integer',
+            description: 'Jobs running longer than this many hours are considered stuck',
+            default: 24,
+            minimum: 1,
+            example: 24
+          }
+        }
+      },
+      response: {
+        200: {
+          description: 'List of stuck jobs',
+          type: 'object',
+          properties: {
+            twitterScraper: {
+              type: 'array',
+              description: 'Stuck jobs in the Twitter scraper queue',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', description: 'Job ID', example: 'twitter-username-1624578901234' },
+                  data: { 
+                    type: 'object', 
+                    description: 'Job data',
+                    additionalProperties: true,
+                    example: {
+                      username: 'elonmusk',
+                      operation: 'scrape-twitter-user'
+                    }
+                  },
+                  state: { type: 'string', description: 'Current job state', example: 'active' },
+                  age: { type: 'string', description: 'How long the job has been running', example: '26 hours' },
+                  attempts: { type: 'integer', description: 'Number of processing attempts', example: 3 }
+                }
+              }
+            },
+            tweetProcessor: {
+              type: 'array',
+              description: 'Stuck jobs in the tweet processor queue',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', description: 'Job ID', example: 'process-username-analytics-1624578901234' },
+                  data: { 
+                    type: 'object', 
+                    description: 'Job data',
+                    additionalProperties: true,
+                    example: {
+                      username: 'elonmusk',
+                      action: 'generate-analytics'
+                    }
+                  },
+                  state: { type: 'string', description: 'Current job state', example: 'active' },
+                  age: { type: 'string', description: 'How long the job has been running', example: '26 hours' },
+                  attempts: { type: 'integer', description: 'Number of processing attempts', example: 3 }
+                }
+              }
+            }
+          }
+        },
+        500: {
+          description: 'Error identifying stuck jobs',
+          type: 'object',
+          properties: {
+            error: { 
+              type: 'string', 
+              description: 'Error message',
+              example: 'Failed to identify stuck jobs: Redis connection error'
+            }
+          }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { hours = 24 } = request.query;
+      const stuckJobs = await twitterService.identifyStuckJobs(parseInt(hours));
+      return stuckJobs;
+    } catch (error) {
+      fastify.log.error(`Failed to identify stuck jobs: ${error.message}`);
+      reply.code(500);
+      return { error: `Failed to identify stuck jobs: ${error.message}` };
+    }
+  });
+
+  // Clean up stuck jobs
+  fastify.post('/cleanup-stuck-jobs', {
+    schema: {
+      description: 'Force terminate and clean up jobs that have been stuck for longer than the specified threshold',
+      tags: ['jobs', 'admin'],
+      body: {
+        type: 'object',
+        properties: {
+          hours: {
+            type: 'integer',
+            description: 'Jobs running longer than this many hours will be terminated',
+            default: 24,
+            minimum: 1,
+            example: 24
+          },
+          dryRun: {
+            type: 'boolean',
+            description: 'If true, only identifies jobs but does not terminate them',
+            default: false,
+            example: true
+          }
+        }
+      },
+      response: {
+        200: {
+          description: 'Results of the cleanup operation',
+          type: 'object',
+          properties: {
+            twitterScraper: {
+              type: 'object',
+              properties: {
+                total: { type: 'integer', description: 'Total number of stuck jobs found', example: 3 },
+                succeeded: { type: 'integer', description: 'Number of jobs successfully terminated', example: 2 },
+                failed: { type: 'integer', description: 'Number of jobs that could not be terminated', example: 1 },
+                details: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string', description: 'Job ID', example: 'twitter-username-1624578901234' },
+                      status: { type: 'string', description: 'Termination status', example: 'terminated' },
+                      message: { type: 'string', description: 'Success message', example: 'Successfully terminated job after 26 hours' },
+                      error: { type: 'string', description: 'Error message if failed', example: 'Job could not be removed because it is locked' }
+                    }
+                  }
+                }
+              }
+            },
+            tweetProcessor: {
+              type: 'object',
+              properties: {
+                total: { type: 'integer', description: 'Total number of stuck jobs found', example: 1 },
+                succeeded: { type: 'integer', description: 'Number of jobs successfully terminated', example: 1 },
+                failed: { type: 'integer', description: 'Number of jobs that could not be terminated', example: 0 },
+                details: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string', description: 'Job ID', example: 'process-username-analytics-1624578901234' },
+                      status: { type: 'string', description: 'Termination status', example: 'terminated' },
+                      message: { type: 'string', description: 'Success message', example: 'Successfully terminated job after 26 hours' },
+                      error: { type: 'string', description: 'Error message if failed', example: null }
+                    }
+                  }
+                }
+              }
+            },
+            dryRun: { type: 'boolean', description: 'Whether this was a dry run (no actual termination)', example: true }
+          }
+        },
+        500: {
+          description: 'Error cleaning up stuck jobs',
+          type: 'object',
+          properties: {
+            error: { 
+              type: 'string', 
+              description: 'Error message',
+              example: 'Failed to clean up stuck jobs: Redis connection error'
+            }
+          }
+        }
+      }
+    }
+  }, async (request, reply) => {
+    try {
+      const { hours = 24, dryRun = false } = request.body;
+      
+      if (dryRun) {
+        // Just identify the jobs but don't clean them up
+        const stuckJobs = await twitterService.identifyStuckJobs(parseInt(hours));
+        return {
+          twitterScraper: {
+            total: stuckJobs.twitterScraper.length,
+            succeeded: 0,
+            failed: 0,
+            details: stuckJobs.twitterScraper.map(job => ({
+              id: job.id,
+              status: 'identified',
+              message: `Job would be terminated (running for ${job.age})`
+            }))
+          },
+          tweetProcessor: {
+            total: stuckJobs.tweetProcessor.length,
+            succeeded: 0,
+            failed: 0,
+            details: stuckJobs.tweetProcessor.map(job => ({
+              id: job.id,
+              status: 'identified',
+              message: `Job would be terminated (running for ${job.age})`
+            }))
+          },
+          dryRun: true
+        };
+      }
+      
+      // Actually clean up the jobs
+      const results = await twitterService.cleanupStuckJobs(parseInt(hours));
+      return results;
+    } catch (error) {
+      fastify.log.error(`Failed to clean up stuck jobs: ${error.message}`);
+      reply.code(500);
+      return { error: `Failed to clean up stuck jobs: ${error.message}` };
     }
   });
 

--- a/api/services/TwitterService.js
+++ b/api/services/TwitterService.js
@@ -452,9 +452,10 @@ class TwitterService {
    * Cancel and remove a job
    * 
    * @param {string} jobId - ID of the job to cancel
-   * @returns {boolean} - Success status
+   * @param {boolean} force - Whether to force unlock and remove the job
+   * @returns {Object} - Operation result with success status and error information if applicable
    */
-  async cancelJob(jobId) {
+  async cancelJob(jobId, force = false) {
     // Try to find job in either queue
     let job = await this.queues.twitterScraper.getJob(jobId);
     let queueName = 'twitterScraper';
@@ -465,16 +466,74 @@ class TwitterService {
     }
     
     if (!job) {
-      return false;
+      return { success: false, error: 'Job not found' };
     }
     
-    // Remove the job
-    await job.remove();
-    
-    // Also try to clean up any in-progress resources
-    await this.redis.set(`cancel:${jobId}`, '1', 'EX', 3600); // signal to worker to cancel
-    
-    return true;
+    try {
+      // If force is true, we'll try to unlock the job first
+      if (force) {
+        // Get current job state to see if it's locked
+        const jobState = await job.getState();
+        this.fastify.log.info(`Attempting to force cancel job ${jobId} in state: ${jobState}`);
+        
+        // Make a direct Redis call to remove the lock
+        // The Redis key format that BullMQ uses for locks is: `bull:${queueName}:${jobId}:lock`
+        const lockKey = `bull:${queueName}:${jobId}:lock`;
+        const wasLocked = await this.redis.del(lockKey);
+        
+        if (wasLocked) {
+          this.fastify.log.info(`Successfully removed lock for job ${jobId}`);
+        }
+        
+        // Also try to clean up active job in case it's still in the active list
+        // BullMQ stores active jobs in a list with key: `bull:${queueName}:active`
+        try {
+          await this.redis.lrem(`bull:${queueName}:active`, 0, jobId);
+          this.fastify.log.info(`Removed job ${jobId} from active list`);
+        } catch (err) {
+          this.fastify.log.warn(`Could not remove job ${jobId} from active list: ${err.message}`);
+        }
+      }
+      
+      // Remove the job
+      await job.remove();
+      
+      // Also try to clean up any in-progress resources
+      await this.redis.set(`cancel:${jobId}`, '1', 'EX', 3600); // signal to worker to cancel
+      
+      // If we have an active pipeline, try to interrupt it
+      if (global.activePipelines && global.activePipelines[jobId]) {
+        try {
+          global.activePipelines[jobId].interrupt();
+          this.fastify.log.info(`Successfully interrupted pipeline for job ${jobId}`);
+          delete global.activePipelines[jobId];
+        } catch (err) {
+          this.fastify.log.error(`Failed to interrupt pipeline: ${err.message}`);
+        }
+      }
+      
+      return { success: true };
+    } catch (error) {
+      this.fastify.log.error(`Error cancelling job ${jobId}: ${error.message}`);
+      
+      // Don't throw, return error information instead
+      let errorMessage = error.message;
+      let errorType = 'unknown';
+      
+      if (error.message.includes("locked by another worker")) {
+        errorType = 'locked';
+        if (!force) {
+          this.fastify.log.warn(`Job ${jobId} is locked. Try with force=true parameter.`);
+        }
+      }
+      
+      return { 
+        success: false, 
+        error: errorMessage,
+        errorType,
+        needsForce: errorType === 'locked' && !force
+      };
+    }
   }
 
   /**
@@ -594,6 +653,256 @@ class TwitterService {
       maxId,
       totalTweets
     };
+  }
+
+  /**
+   * Identify stuck jobs that have been running for too long
+   * 
+   * @param {number} thresholdHours - Jobs running longer than this many hours are considered stuck (default: 24 hours)
+   * @returns {Object} - List of stuck jobs by queue
+   */
+  async identifyStuckJobs(thresholdHours = 24) {
+    const thresholdMs = thresholdHours * 60 * 60 * 1000;
+    const now = Date.now();
+    
+    // Get all active jobs from both queues
+    const twitterScraperActive = await this.queues.twitterScraper.getActive();
+    const tweetProcessorActive = await this.queues.tweetProcessor.getActive();
+    
+    // Filter for jobs that have been active for too long
+    const stuckTwitterJobs = twitterScraperActive.filter(job => {
+      // Check if job has been processing for longer than threshold
+      return job.processedOn && (now - job.processedOn) > thresholdMs;
+    });
+    
+    const stuckProcessorJobs = tweetProcessorActive.filter(job => {
+      return job.processedOn && (now - job.processedOn) > thresholdMs;
+    });
+    
+    // Also check for jobs that have been in "waiting" or "delayed" state for too long
+    // These could be jobs that the worker has crashed while processing
+    const waitingTwitterJobs = await this.queues.twitterScraper.getWaiting();
+    const delayedTwitterJobs = await this.queues.twitterScraper.getDelayed();
+    
+    // Filter for waiting/delayed jobs that are too old
+    const stuckWaitingTwitterJobs = waitingTwitterJobs.filter(job => {
+      // Check if job was created too long ago and has a high attempt count
+      return job.timestamp && (now - job.timestamp) > thresholdMs && job.attemptsMade > 2;
+    });
+    
+    const stuckDelayedTwitterJobs = delayedTwitterJobs.filter(job => {
+      return job.timestamp && (now - job.timestamp) > thresholdMs && job.attemptsMade > 2;
+    });
+    
+    // Combine all stuck Twitter jobs
+    const allStuckTwitterJobs = [...stuckTwitterJobs, ...stuckWaitingTwitterJobs, ...stuckDelayedTwitterJobs];
+    
+    // Get job states - we need to handle the awaits properly
+    const twitterScraperResults = await Promise.all(
+      allStuckTwitterJobs.map(async (job) => {
+        let state = 'unknown';
+        if (job.getState) {
+          try {
+            state = await job.getState();
+          } catch (err) {
+            this.fastify.log.error(`Error getting state for job ${job.id}: ${err.message}`);
+          }
+        }
+        
+        return {
+          id: job.id,
+          data: job.data,
+          state,
+          age: job.processedOn ? Math.round((now - job.processedOn) / (60 * 60 * 1000)) + ' hours' : 'unknown',
+          attempts: job.attemptsMade
+        };
+      })
+    );
+    
+    const tweetProcessorResults = await Promise.all(
+      stuckProcessorJobs.map(async (job) => {
+        let state = 'unknown';
+        if (job.getState) {
+          try {
+            state = await job.getState();
+          } catch (err) {
+            this.fastify.log.error(`Error getting state for job ${job.id}: ${err.message}`);
+          }
+        }
+        
+        return {
+          id: job.id,
+          data: job.data,
+          state,
+          age: job.processedOn ? Math.round((now - job.processedOn) / (60 * 60 * 1000)) + ' hours' : 'unknown',
+          attempts: job.attemptsMade
+        };
+      })
+    );
+    
+    return {
+      twitterScraper: twitterScraperResults,
+      tweetProcessor: tweetProcessorResults
+    };
+  }
+
+  /**
+   * Clean up stuck jobs
+   * 
+   * @param {number} thresholdHours - Jobs running longer than this many hours will be terminated
+   * @returns {Object} - Results of the cleanup operation
+   */
+  async cleanupStuckJobs(thresholdHours = 24) {
+    const stuckJobs = await this.identifyStuckJobs(thresholdHours);
+    const results = {
+      twitterScraper: { total: stuckJobs.twitterScraper.length, succeeded: 0, failed: 0, details: [] },
+      tweetProcessor: { total: stuckJobs.tweetProcessor.length, succeeded: 0, failed: 0, details: [] }
+    };
+    
+    // Process Twitter scraper jobs
+    for (const job of stuckJobs.twitterScraper) {
+      try {
+        this.fastify.log.warn(`Force terminating stuck job ${job.id} (${job.age} old, ${job.attempts} attempts)`);
+        
+        // Force terminate with our enhanced cancel method
+        const result = await this.cancelJob(job.id, true);
+        
+        if (result.success) {
+          results.twitterScraper.succeeded++;
+          results.twitterScraper.details.push({
+            id: job.id,
+            status: 'terminated',
+            message: `Successfully terminated job after ${job.age}`
+          });
+        } else {
+          results.twitterScraper.failed++;
+          results.twitterScraper.details.push({
+            id: job.id,
+            status: 'failed',
+            error: result.error
+          });
+          
+          // If the normal force cancel didn't work, try more aggressive Redis cleanup
+          await this.forceRemoveJobFromRedis('twitterScraper', job.id);
+        }
+      } catch (error) {
+        results.twitterScraper.failed++;
+        results.twitterScraper.details.push({
+          id: job.id,
+          status: 'error',
+          error: error.message
+        });
+      }
+    }
+    
+    // Process tweet processor jobs
+    for (const job of stuckJobs.tweetProcessor) {
+      try {
+        this.fastify.log.warn(`Force terminating stuck job ${job.id} (${job.age} old, ${job.attempts} attempts)`);
+        
+        const result = await this.cancelJob(job.id, true);
+        
+        if (result.success) {
+          results.tweetProcessor.succeeded++;
+          results.tweetProcessor.details.push({
+            id: job.id,
+            status: 'terminated',
+            message: `Successfully terminated job after ${job.age}`
+          });
+        } else {
+          results.tweetProcessor.failed++;
+          results.tweetProcessor.details.push({
+            id: job.id,
+            status: 'failed',
+            error: result.error
+          });
+          
+          // If the normal force cancel didn't work, try more aggressive Redis cleanup
+          await this.forceRemoveJobFromRedis('tweetProcessor', job.id);
+        }
+      } catch (error) {
+        results.tweetProcessor.failed++;
+        results.tweetProcessor.details.push({
+          id: job.id,
+          status: 'error',
+          error: error.message
+        });
+      }
+    }
+    
+    return results;
+  }
+  
+  /**
+   * Force remove a job from Redis using direct Redis commands
+   * This is a last resort when all other methods fail
+   * 
+   * @param {string} queueName - Name of the queue ('twitterScraper' or 'tweetProcessor')
+   * @param {string} jobId - ID of the job to remove
+   * @returns {boolean} - Whether the operation succeeded
+   */
+  async forceRemoveJobFromRedis(queueName, jobId) {
+    try {
+      // Convert our queue name to the actual Bull queue name
+      const bullQueueName = queueName === 'twitterScraper' ? 'twitter-scraper' : 'tweet-processor';
+      
+      // The key prefix in Redis
+      const prefix = `bull:${bullQueueName}:`;
+      
+      // Log what we're about to do
+      this.fastify.log.warn(`Performing aggressive Redis cleanup for job ${jobId} in queue ${bullQueueName}`);
+      
+      // Remove from all possible states in Redis
+      const keys = [
+        `${prefix}${jobId}`, // The job hash itself
+        `${prefix}${jobId}:lock`, // Job lock
+        `${prefix}active`, // Active set
+        `${prefix}wait`, // Waiting list
+        `${prefix}delayed`, // Delayed zset
+        `${prefix}failed`, // Failed set
+        `${prefix}stalled` // Stalled set
+      ];
+      
+      // Delete the job data
+      await this.redis.del(`${prefix}${jobId}`);
+      
+      // Remove lock if exists
+      await this.redis.del(`${prefix}${jobId}:lock`);
+      
+      // Remove from active list
+      await this.redis.lrem(`${prefix}active`, 0, jobId);
+      
+      // Remove from wait list
+      await this.redis.lrem(`${prefix}wait`, 0, jobId);
+      
+      // Remove from delayed zset
+      await this.redis.zrem(`${prefix}delayed`, jobId);
+      
+      // Remove from failed set
+      await this.redis.zrem(`${prefix}failed`, jobId);
+      
+      // Remove from stalled set
+      await this.redis.srem(`${prefix}stalled`, jobId);
+      
+      // Signal cancellation
+      await this.redis.set(`cancel:${jobId}`, '1', 'EX', 3600);
+      
+      // Remove from active pipelines if it exists
+      if (global.activePipelines && global.activePipelines[jobId]) {
+        try {
+          global.activePipelines[jobId].interrupt();
+          delete global.activePipelines[jobId];
+        } catch (err) {
+          this.fastify.log.error(`Failed to interrupt pipeline: ${err.message}`);
+        }
+      }
+      
+      this.fastify.log.info(`Successfully performed Redis cleanup for job ${jobId}`);
+      return true;
+    } catch (error) {
+      this.fastify.log.error(`Failed to clean up job ${jobId} from Redis: ${error.message}`);
+      return false;
+    }
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   twitter-api:
     build:
@@ -9,26 +7,35 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./cookies:/app/cookies
-      - ./data:/app/data
+      - ./cookies:/usr/src/app/cookies
+      - ./data:/usr/src/app/data
+      - ./logs:/usr/src/app/logs
     environment:
-      # Database connection
+      # API Configuration
+      PORT: 3000
+      HOST: 0.0.0.0
+      NODE_ENV: production
+      KEEP_CONNECTION_OPEN: 'true'
+      
+      # Database Configuration
       DB_HOST: postgres
       DB_PORT: 5432
-      DB_USER: postgres
+      DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_NAME: twitter_scraper
+      DB_DATABASE: twitter_scraper
+      POSTGRES_SSL: 'false'  # Disable SSL for Docker PostgreSQL
       
-      # Redis connection
+      # Redis Configuration
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ''
       
       # Twitter Credentials (set these in a .env file or pass directly)
       # TWITTER_USERNAME: ${TWITTER_USERNAME}
       # TWITTER_PASSWORD: ${TWITTER_PASSWORD}
       # TWITTER_EMAIL: ${TWITTER_EMAIL}
       
-      # Twitter Scraper Settings (adjust as needed)
+      # Twitter Scraper Settings
       MAX_TWEETS: 50000
       MAX_RETRIES: 5
       RETRY_DELAY: 5000
@@ -36,26 +43,29 @@ services:
       MAX_DELAY: 3000
       RATE_LIMIT_THRESHOLD: 3
       
-      # Timeout Settings (adjust as needed)
+      # Timeout Settings
       COLLECTION_GLOBAL_TIMEOUT: 120000     # 2 minutes
-      COLLECTION_STALL_TIMEOUT: 15000      # 15 seconds
-      COLLECTION_PROGRESS_CHECK: 2000      # 2 seconds
-      JOB_STALL_TIMEOUT: 45000             # 45 seconds
-      JOB_PROGRESS_CHECK: 5000             # 5 seconds
-      FORCED_BREAK_TIMEOUT: 120000         # 2 minutes
+      COLLECTION_STALL_TIMEOUT: 15000       # 15 seconds
+      COLLECTION_PROGRESS_CHECK: 2000       # 2 seconds
+      JOB_STALL_TIMEOUT: 45000              # 45 seconds
+      JOB_PROGRESS_CHECK: 5000              # 5 seconds
+      FORCED_BREAK_TIMEOUT: 120000          # 2 minutes
       
-      # Rate Limit Settings (adjust as needed)
-      RATE_LIMIT_BASE_DELAY: 60000         # 1 minute
-      RATE_LIMIT_MAX_DELAY: 900000         # 15 minutes
-      RATE_LIMIT_DURATION: 900000          # 15 minutes
-      RATE_LIMIT_KEY_EXPIRY: 900           # 15 minutes
+      # Rate Limit Settings
+      RATE_LIMIT_BASE_DELAY: 60000          # 1 minute
+      RATE_LIMIT_MAX_DELAY: 900000          # 15 minutes
+      RATE_LIMIT_DURATION: 900000           # 15 minutes
+      RATE_LIMIT_KEY_EXPIRY: 900            # 15 minutes
       
-      # Redis Key Settings (adjust as needed)
-      NON_RETRIABLE_KEY_EXPIRY: 86400      # 24 hours
-      PROGRESS_KEY_EXPIRY: 3600            # 1 hour
+      # Redis Key Settings
+      NON_RETRIABLE_KEY_EXPIRY: 86400       # 24 hours
+      PROGRESS_KEY_EXPIRY: 3600             # 1 hour
       
-      # Node.js settings
-      NODE_ENV: production
+      # Logging Configuration
+      LOG_LEVEL: info
+      LOG_DIR: /usr/src/app/logs
+      LOG_TO_FILE: 'true'
+      DEBUG: 'false'
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/twitter/health"]
@@ -63,6 +73,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    command: ["/usr/src/app/entrypoint-with-migrations.sh"]
 
   redis:
     image: redis:7
@@ -83,9 +94,9 @@ services:
     image: postgres:14
     container_name: twitter-scraper-postgres
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: twitter_scraper
+      POSTGRES_USER: postgres       # This maps to DB_USERNAME in the API service
+      POSTGRES_PASSWORD: postgres   # This maps to DB_PASSWORD in the API service
+      POSTGRES_DB: twitter_scraper  # This maps to DB_DATABASE in the API service
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
feat: implement automatic job cleanup for stuck jobs

- Added environment variables to .env.example for enabling automatic job cleanup and configuring intervals and thresholds.
- Enhanced queue.js to set up a scheduled cleanup process for jobs that have been stuck for longer than the specified threshold.
- Updated TwitterService to include methods for identifying and cleaning up stuck jobs, improving job management and system resilience.
- Modified Twitter routes to provide endpoints for identifying and cleaning up stuck jobs, enhancing administrative capabilities.